### PR TITLE
Clip AWB mode bounds to the measured colour temperature range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: check .
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check .
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install -e ".[test]"
+      - run: pytest -v

--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ python3 -m ruff format .
 python3 -m ruff format --check .
 ```
 
+### Running tests
+
+Install with the test extra and run pytest:
+
+```bash
+pip install -e ".[test]"
+pytest -v
+```
+
 ### Building a wheel package
 
 ```bash

--- a/ctt/algorithms/awb.py
+++ b/ctt/algorithms/awb.py
@@ -67,6 +67,20 @@ class AwbCalibration(CalibrationAlgorithm):
         awb_out = awb(cam, colour_cals, grid_size, plot=do_plot)
         ct_curve, transverse_neg, transverse_pos = awb_out
 
+        # Clip AWB mode bounds to the measured CT range.
+        ct_min = ct_curve[0]  # ct_curve is [ct, r, b, ct, r, b, ...] increasing CT
+        ct_max = ct_curve[-3]
+        modes = cam.json.get('rpi.awb', {}).get('modes', {})
+        for name, mode in modes.items():
+            lo = max(mode['lo'], ct_min)
+            hi = min(mode['hi'], ct_max)
+            if lo > hi:
+                lo = hi = ct_min if mode['hi'] < ct_min else ct_max
+            if lo != mode['lo'] or hi != mode['hi']:
+                cam.log += f'\nAWB mode {name}: clipped [{mode["lo"]}, {mode["hi"]}] -> [{lo}, {hi}]'
+                mode['lo'] = lo
+                mode['hi'] = hi
+
         result['ct_curve'] = ct_curve
         result['sensitivity_r'] = 1.0
         result['sensitivity_b'] = 1.0

--- a/ctt/output/converter.py
+++ b/ctt/output/converter.py
@@ -9,6 +9,7 @@
 import json
 
 import numpy as np
+from scipy.ndimage import zoom
 
 from ..platforms import pisp as pisp_mod
 from ..platforms import vc4 as vc4_mod
@@ -22,12 +23,7 @@ def _load_template(platform_mod: object) -> dict:
 
 
 def interp_2d(in_ls: np.ndarray, src_w: int, src_h: int, dst_w: int, dst_h: int) -> np.ndarray:
-    out_ls = np.zeros((dst_h, dst_w))
-    for i in range(src_h):
-        out_ls[i] = np.interp(np.linspace(0, dst_w - 1, dst_w), np.linspace(0, dst_w - 1, src_w), in_ls[i])
-    for i in range(dst_w):
-        out_ls[:, i] = np.interp(np.linspace(0, dst_h - 1, dst_h), np.linspace(0, dst_h - 1, src_h), out_ls[:src_h, i])
-    return out_ls
+    return zoom(in_ls, (dst_h / src_h, dst_w / src_w), order=1)
 
 
 def convert_target(in_json: dict, target: str) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     "scipy>=1.17",
 ]
 
+[project.optional-dependencies]
+test = ["pytest>=8.0"]
+
 [project.scripts]
 ctt = "ctt.ctt:main"
 
@@ -30,6 +33,9 @@ include = ["ctt*"]
 
 [tool.setuptools.package-data]
 "ctt.data" = ["*.pgm", "*.json"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.ruff]
 target-version = "py311"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (C) 2026, Raspberry Pi
+
+import numpy as np
+
+from ctt.core.camera import _LogBuffer, get_col_lux
+from ctt.core.image import Image
+
+# --- _LogBuffer ---
+
+
+class TestLogBuffer:
+    def test_empty(self):
+        buf = _LogBuffer()
+        assert str(buf) == ''
+
+    def test_initial(self):
+        buf = _LogBuffer('hello')
+        assert str(buf) == 'hello'
+
+    def test_accumulate(self):
+        buf = _LogBuffer()
+        buf += 'hello'
+        buf += ' world'
+        assert str(buf) == 'hello world'
+
+    def test_iadd_returns_self(self):
+        buf = _LogBuffer()
+        result = buf.__iadd__('test')
+        assert result is buf
+
+
+# --- get_col_lux ---
+
+
+class TestGetColLux:
+    def test_col_and_lux(self):
+        assert get_col_lux('d65_5500k_1000l.dng') == (5500, 1000)
+
+    def test_col_only(self):
+        assert get_col_lux('alsc_3000k.dng') == (3000, None)
+
+    def test_uppercase_k(self):
+        assert get_col_lux('image_4000K_500L.dng') == (4000, 500)
+
+    def test_no_col(self):
+        assert get_col_lux('invalid.dng') == (None, None)
+
+    def test_no_extension(self):
+        assert get_col_lux('image_5000k') == (None, None)
+
+    def test_jpg_extension(self):
+        assert get_col_lux('image_5000k_200l.jpg') == (5000, 200)
+
+    def test_col_with_suffix(self):
+        assert get_col_lux('alsc_3000k_0.dng') == (3000, None)
+
+
+# --- Image.get_patches ---
+
+
+class TestImageGetPatches:
+    def _make_image(self, h=64, w=64, sigbits=10):
+        img = Image()
+        img.sigbits = sigbits
+        img.channels = [np.full((h, w), 100, dtype=np.int64) for _ in range(4)]
+        return img
+
+    def test_basic_extraction(self):
+        img = self._make_image()
+        coords = [[[32, 32]]]  # Single patch at centre
+        img.get_patches(coords)
+        assert img.patches is not None
+        assert len(img.patches) == 4  # One per channel
+        assert len(img.patches[0]) == 1  # One patch
+
+    def test_patch_size(self):
+        img = self._make_image()
+        coords = [[[32, 32]]]
+        img.get_patches(coords, size=8)
+        assert len(img.patches[0][0]) == 64  # 8x8 flattened
+
+    def test_not_saturated(self):
+        img = self._make_image(sigbits=10)
+        coords = [[[32, 32]]]
+        img.get_patches(coords)
+        assert img.saturated is False
+
+    def test_saturated_detection(self):
+        img = self._make_image(sigbits=10)
+        # Fill with the saturation value: (2^10 - 1) * 2^(16-10) = 1023 * 64
+        sat_val = (2**10 - 1) * 2 ** (16 - 10)
+        for ch in img.channels:
+            ch[:] = sat_val
+        coords = [[[32, 32]]]
+        img.get_patches(coords)
+        assert img.saturated is True
+
+    def test_edge_clamping(self):
+        img = self._make_image()
+        # Patch at corner should be clamped, not error
+        coords = [[[0, 0]]]
+        img.get_patches(coords)
+        assert img.patches is not None
+
+    def test_multiple_patches(self):
+        img = self._make_image()
+        coords = [[[10, 10], [30, 30], [50, 50]]]
+        img.get_patches(coords)
+        assert len(img.patches[0]) == 3

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (C) 2026, Raspberry Pi
+
+import numpy as np
+
+from ctt.detection.ransac import get_square_centres, get_square_verts
+
+
+class TestGetSquareVerts:
+    def test_returns_24_squares(self):
+        verts, mac_norm = get_square_verts()
+        assert verts.shape[0] == 24
+
+    def test_each_square_has_4_vertices(self):
+        verts, _ = get_square_verts()
+        assert verts.shape[1] == 4
+
+    def test_vertices_2d(self):
+        verts, _ = get_square_verts()
+        assert verts.shape[2] == 2
+
+    def test_all_vertices_within_chart(self):
+        verts, mac_norm = get_square_verts()
+        x_max = mac_norm[0, 3, 0]  # top-right x
+        y_max = mac_norm[0, 1, 1]  # bottom-left y
+        assert np.all(verts[:, :, 0] >= 0)
+        assert np.all(verts[:, :, 1] >= 0)
+        assert np.all(verts[:, :, 0] <= x_max)
+        assert np.all(verts[:, :, 1] <= y_max)
+
+    def test_chart_boundary_shape(self):
+        _, mac_norm = get_square_verts()
+        assert mac_norm.shape == (1, 4, 2)
+
+    def test_different_scale(self):
+        verts_s1, _ = get_square_verts(scale=1)
+        verts_s2, _ = get_square_verts(scale=2)
+        # Scale 2 should produce coordinates roughly 2x those of scale 1
+        ratio = np.mean(verts_s2) / np.mean(verts_s1)
+        assert ratio > 1.9 and ratio < 2.1
+
+
+class TestGetSquareCentres:
+    def test_returns_24_centres(self):
+        centres = get_square_centres()
+        assert centres.shape[0] == 24
+
+    def test_centres_2d(self):
+        centres = get_square_centres()
+        assert centres.shape[1] == 2
+
+    def test_centres_within_squares(self):
+        verts, _ = get_square_verts()
+        centres = get_square_centres()
+        for i in range(24):
+            cx, cy = centres[i]
+            xs = verts[i, :, 0]
+            ys = verts[i, :, 1]
+            assert cx >= np.min(xs) and cx <= np.max(xs)
+            assert cy >= np.min(ys) and cy <= np.max(ys)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (C) 2026, Raspberry Pi
+
+import json
+
+import numpy as np
+import pytest
+
+from ctt.output.converter import convert_target, convert_v2, interp_2d
+from ctt.output.json_formatter import Encoder, pretty_print
+
+# --- pretty_print ---
+
+
+class TestPrettyPrint:
+    @pytest.fixture()
+    def valid_json(self):
+        return {
+            'version': 2.0,
+            'target': 'pisp',
+            'algorithms': [{'rpi.black_level': {'black_level': 4096}}],
+        }
+
+    def test_valid_json(self, valid_json):
+        result = pretty_print(valid_json)
+        assert isinstance(result, str)
+        # Output should be parseable JSON
+        parsed = json.loads(result)
+        assert parsed['version'] == 2.0
+
+    def test_missing_version_raises(self):
+        with pytest.raises(RuntimeError):
+            pretty_print({'target': 'pisp', 'algorithms': []})
+
+    def test_missing_target_raises(self):
+        with pytest.raises(RuntimeError):
+            pretty_print({'version': 2.0, 'algorithms': []})
+
+    def test_missing_algorithms_raises(self):
+        with pytest.raises(RuntimeError):
+            pretty_print({'version': 2.0, 'target': 'pisp'})
+
+    def test_old_version_raises(self):
+        with pytest.raises(RuntimeError):
+            pretty_print({'version': 1.0, 'target': 'pisp', 'algorithms': []})
+
+    def test_custom_elems(self, valid_json):
+        valid_json['algorithms'] = [{'rpi.awb': {'ct_curve': [3000, 0.5, 0.4, 5000, 0.3, 0.6]}}]
+        result = pretty_print(valid_json, custom_elems={'ct_curve': 3})
+        # ct_curve should be chunked in groups of 3
+        assert 'ct_curve' in result
+
+
+# --- Encoder ---
+
+
+class TestEncoder:
+    def test_flat_list_inline(self):
+        enc = Encoder(indent=4, sort_keys=False)
+        result = enc.encode([1, 2, 3])
+        assert '1' in result and '2' in result and '3' in result
+
+    def test_dict_encoding(self):
+        enc = Encoder(indent=4, sort_keys=False)
+        result = enc.encode({'key': 'value'})
+        parsed = json.loads(result)
+        assert parsed['key'] == 'value'
+
+    def test_nested_list(self):
+        enc = Encoder(indent=4, sort_keys=False)
+        result = enc.encode([[1, 2], [3, 4]])
+        assert '1' in result
+
+    def test_empty_dict(self):
+        enc = Encoder(indent=4, sort_keys=False)
+        result = enc.encode({'empty': {}})
+        assert '{ }' in result
+
+
+# --- interp_2d ---
+
+
+class TestInterp2d:
+    def test_identity(self):
+        grid = np.array([[1.0, 2.0], [3.0, 4.0]])
+        result = interp_2d(grid, 2, 2, 2, 2)
+        np.testing.assert_array_almost_equal(result, grid)
+
+    def test_corners_preserved(self):
+        grid = np.array([[1.0, 2.0], [3.0, 4.0]])
+        result = interp_2d(grid, 2, 2, 4, 4)
+        assert result[0, 0] == pytest.approx(1.0)
+        assert result[0, -1] == pytest.approx(2.0)
+        assert result[-1, 0] == pytest.approx(3.0)
+        assert result[-1, -1] == pytest.approx(4.0)
+
+    def test_upscale_shape(self):
+        grid = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        result = interp_2d(grid, 3, 2, 6, 4)
+        assert result.shape == (4, 6)
+
+    def test_uniform_grid_stays_uniform(self):
+        grid = np.ones((3, 3)) * 5.0
+        result = interp_2d(grid, 3, 3, 6, 6)
+        np.testing.assert_array_almost_equal(result, np.ones((6, 6)) * 5.0)
+
+
+# --- convert_target / convert_v2 ---
+
+
+def _make_pisp_json():
+    """Build a minimal PiSP tuning JSON with ALSC tables and AGC."""
+    rng = np.random.default_rng(42)
+    pisp_w, pisp_h = 32, 32
+    table_size = pisp_w * pisp_h
+
+    alsc_table_cr = np.round(1.0 + rng.random(table_size) * 0.5, 3).tolist()
+    alsc_table_cb = np.round(1.0 + rng.random(table_size) * 0.3, 3).tolist()
+    luminance_lut = np.round(1.0 + rng.random(table_size) * 0.2, 3).tolist()
+
+    return {
+        'version': 2.0,
+        'target': 'pisp',
+        'algorithms': [
+            {
+                'rpi.alsc': {
+                    'omega': 1.3,
+                    'n_iter': 100,
+                    'luminance_strength': 0.8,
+                    'calibrations_Cr': [{'ct': 3000, 'table': alsc_table_cr}],
+                    'calibrations_Cb': [{'ct': 3000, 'table': alsc_table_cb}],
+                    'luminance_lut': luminance_lut,
+                }
+            },
+            {
+                'rpi.denoise': {
+                    'normal': {'noise_constant': 0, 'noise_slope': 2.0},
+                }
+            },
+            {
+                'rpi.agc': {
+                    'channels': [
+                        {
+                            'metering_modes': {
+                                'centre-weighted': {'weights': [1] * 225},
+                                'spot': {'weights': [0] * 225},
+                                'matrix': {'weights': [1] * 225},
+                            },
+                            'exposure_modes': {'normal': {'shutter': [100], 'gain': [1.0]}},
+                            'constraint_modes': {'normal': []},
+                        }
+                    ]
+                }
+            },
+            {'rpi.hdr': {'cadence': [1, 2]}},
+            {'rpi.ccm': {'ccms': [{'ct': 3000, 'ccm': [1, 0, 0, 0, 1, 0, 0, 0, 1]}]}},
+        ],
+    }
+
+
+def _make_vc4_json():
+    """Build a minimal VC4 tuning JSON with ALSC tables and AGC."""
+    rng = np.random.default_rng(42)
+    vc4_w, vc4_h = 16, 12
+    table_size = vc4_w * vc4_h
+
+    alsc_table_cr = np.round(1.0 + rng.random(table_size) * 0.5, 3).tolist()
+    alsc_table_cb = np.round(1.0 + rng.random(table_size) * 0.3, 3).tolist()
+    luminance_lut = np.round(1.0 + rng.random(table_size) * 0.2, 3).tolist()
+
+    return {
+        'version': 2.0,
+        'target': 'bcm2835',
+        'algorithms': [
+            {
+                'rpi.alsc': {
+                    'omega': 1.3,
+                    'n_iter': 100,
+                    'luminance_strength': 0.7,
+                    'calibrations_Cr': [{'ct': 3000, 'table': alsc_table_cr}],
+                    'calibrations_Cb': [{'ct': 3000, 'table': alsc_table_cb}],
+                    'luminance_lut': luminance_lut,
+                }
+            },
+            {
+                'rpi.sdn': {
+                    'noise_constant': 0,
+                    'noise_slope': 2.0,
+                }
+            },
+            {
+                'rpi.agc': {
+                    'metering_modes': {
+                        'centre-weighted': {'weights': [1] * 15},
+                        'spot': {'weights': [0] * 15},
+                        'matrix': {'weights': [1] * 15},
+                    },
+                    'exposure_modes': {'normal': {'shutter': [100], 'gain': [1.0]}},
+                    'constraint_modes': {'normal': []},
+                }
+            },
+            {'rpi.ccm': {'ccms': [{'ct': 3000, 'ccm': [1, 0, 0, 0, 1, 0, 0, 0, 1]}]}},
+        ],
+    }
+
+
+class TestConvertTarget:
+    def test_vc4_to_pisp_alsc_table_size(self):
+        vc4_json = _make_vc4_json()
+        result = convert_target(vc4_json, 'pisp')
+        alsc = next(a for a in result['algorithms'] if 'rpi.alsc' in a)['rpi.alsc']
+        # PiSP grid is 32x32 = 1024
+        assert len(alsc['calibrations_Cr'][0]['table']) == 32 * 32
+        assert len(alsc['calibrations_Cb'][0]['table']) == 32 * 32
+        assert len(alsc['luminance_lut']) == 32 * 32
+
+    def test_vc4_to_pisp_agc_weights_replaced(self):
+        vc4_json = _make_vc4_json()
+        result = convert_target(vc4_json, 'pisp')
+        agc = next(a for a in result['algorithms'] if 'rpi.agc' in a)['rpi.agc']
+        # VC4 flat metering_modes should get PiSP template weights (225 elements)
+        weights = agc['metering_modes']['centre-weighted']['weights']
+        assert len(weights) == 225
+
+    def test_vc4_to_pisp_sdn_becomes_denoise(self):
+        vc4_json = _make_vc4_json()
+        result = convert_target(vc4_json, 'pisp')
+        algo_keys = [k for a in result['algorithms'] for k in a]
+        assert 'rpi.denoise' in algo_keys
+        assert 'rpi.sdn' not in algo_keys
+
+    def test_vc4_to_pisp_uniform_alsc(self):
+        vc4_json = _make_vc4_json()
+        alsc = next(a for a in vc4_json['algorithms'] if 'rpi.alsc' in a)['rpi.alsc']
+        alsc['calibrations_Cr'][0]['table'] = [1.0] * (16 * 12)
+        alsc['calibrations_Cb'][0]['table'] = [1.0] * (16 * 12)
+        alsc['luminance_lut'] = [1.0] * (16 * 12)
+
+        result = convert_target(vc4_json, 'pisp')
+        alsc_out = next(a for a in result['algorithms'] if 'rpi.alsc' in a)['rpi.alsc']
+        np.testing.assert_array_almost_equal(alsc_out['calibrations_Cr'][0]['table'], [1.0] * (32 * 32))
+
+    def test_vc4_to_pisp_preserves_alsc_range(self):
+        vc4_json = _make_vc4_json()
+        alsc = next(a for a in vc4_json['algorithms'] if 'rpi.alsc' in a)['rpi.alsc']
+        original_min = min(alsc['calibrations_Cr'][0]['table'])
+        original_max = max(alsc['calibrations_Cr'][0]['table'])
+
+        result = convert_target(vc4_json, 'pisp')
+        alsc_out = next(a for a in result['algorithms'] if 'rpi.alsc' in a)['rpi.alsc']
+        result_min = min(alsc_out['calibrations_Cr'][0]['table'])
+        result_max = max(alsc_out['calibrations_Cr'][0]['table'])
+        # Interpolation should not produce values outside the original range
+        assert result_min >= original_min - 0.001
+        assert result_max <= original_max + 0.001
+
+
+class TestConvertV2:
+    def test_vc4_to_pisp_produces_valid_json(self):
+        vc4_json = _make_vc4_json()
+        result_str = convert_v2(vc4_json, 'pisp')
+        parsed = json.loads(result_str)
+        assert parsed['target'] == 'pisp'
+        assert parsed['version'] == 2.0
+
+    def test_same_target_no_conversion(self):
+        pisp_json = _make_pisp_json()
+        alsc_before = next(a for a in pisp_json['algorithms'] if 'rpi.alsc' in a)['rpi.alsc']
+        table_before = list(alsc_before['calibrations_Cr'][0]['table'])
+        result_str = convert_v2(pisp_json, 'pisp')
+        parsed = json.loads(result_str)
+        alsc_after = next(a for a in parsed['algorithms'] if 'rpi.alsc' in a)['rpi.alsc']
+        assert alsc_after['calibrations_Cr'][0]['table'] == table_before
+
+    def test_v1_to_v2_conversion(self):
+        v1_json = {
+            'version': 1.0,
+            'rpi.black_level': {'black_level': 4096},
+        }
+        result_str = convert_v2(v1_json, 'pisp')
+        parsed = json.loads(result_str)
+        assert parsed['version'] == 2.0
+        assert parsed['target'] == 'pisp'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (C) 2026, Raspberry Pi
+
+import numpy as np
+import pytest
+
+from ctt.utils.colorspace import rgb_to_lab
+from ctt.utils.tools import correlate, get_alsc_colour_cals, nudge_for_json, reshape
+
+# --- nudge_for_json ---
+
+
+class TestNudgeForJson:
+    def test_normal_values_unchanged(self):
+        arr = np.array([1.234, 2.567, 3.891])
+        result = nudge_for_json(arr, decimals=3)
+        np.testing.assert_array_equal(result, np.round(arr, 3))
+
+    def test_nudges_trailing_zero(self):
+        # 1.200 → factor*arr % 1 = 12.0 % 1 = 0.0 ≤ 0.05, so nudged up
+        arr = np.array([1.200])
+        result = nudge_for_json(arr, decimals=3)
+        assert result[0] != 1.200
+
+    def test_nudges_trailing_nine(self):
+        # decimals=1, factor=1: (1 * 0.99) % 1 = 0.99 ≥ 0.95 → nudged down
+        # Without nudge: round(0.99, 1) = 1.0; with nudge: round(0.89, 1) = 0.9
+        arr = np.array([0.99])
+        result = nudge_for_json(arr, decimals=1)
+        assert result[0] == pytest.approx(0.9)
+
+    def test_decimals_4(self):
+        arr = np.array([0.5, 1.0, 2.5])
+        result = nudge_for_json(arr, decimals=4)
+        for val in result:
+            # All results should round to 4 dp
+            assert val == round(val, 4)
+
+    def test_empty_array(self):
+        arr = np.array([])
+        result = nudge_for_json(arr)
+        assert len(result) == 0
+
+
+# --- correlate ---
+
+
+class TestCorrelate:
+    def test_identical(self):
+        a = np.array([[1, 2, 3], [4, 5, 6]])
+        assert correlate(a, a) == pytest.approx(1.0)
+
+    def test_anticorrelated(self):
+        a = np.array([1.0, 2.0, 3.0])
+        b = np.array([3.0, 2.0, 1.0])
+        assert correlate(a, b) == pytest.approx(-1.0)
+
+    def test_constant_array(self):
+        a = np.array([1.0, 2.0, 3.0])
+        b = np.ones(3)
+        # Correlation with constant is NaN
+        assert np.isnan(correlate(a, b))
+
+
+# --- get_alsc_colour_cals ---
+
+
+class TestGetAlscColourCals:
+    def test_missing_key_returns_none(self):
+        assert get_alsc_colour_cals({}) is None
+        assert get_alsc_colour_cals({'rpi.alsc': {}}) is None
+
+    def test_valid_json(self):
+        cam_json = {
+            'rpi.alsc': {
+                'calibrations_Cr': [
+                    {'ct': 3000, 'table': np.array([2.0, 4.0, 6.0])},
+                    {'ct': 5000, 'table': np.array([1.0, 3.0, 5.0])},
+                ],
+                'calibrations_Cb': [
+                    {'ct': 3000, 'table': np.array([3.0, 6.0, 9.0])},
+                    {'ct': 5000, 'table': np.array([2.0, 4.0, 8.0])},
+                ],
+            }
+        }
+        result = get_alsc_colour_cals(cam_json)
+        assert result is not None
+        assert set(result.keys()) == {3000, 5000}
+        # Tables should be normalised so min is 1.0
+        for _ct, (cr, cb) in result.items():
+            assert np.min(cr) == pytest.approx(1.0)
+            assert np.min(cb) == pytest.approx(1.0)
+
+
+# --- reshape ---
+
+
+class TestReshape:
+    def test_output_dimensions(self):
+        img = np.zeros((100, 200, 3), dtype=np.uint8)
+        resized, factor = reshape(img, 50)
+        assert resized.shape[0] == 50
+        assert factor == pytest.approx(0.5)
+
+    def test_factor_calculation(self):
+        img = np.zeros((200, 400, 3), dtype=np.uint8)
+        _, factor = reshape(img, 100)
+        assert factor == pytest.approx(0.5)
+
+
+# --- rgb_to_lab ---
+
+
+class TestRgbToLab:
+    def test_black(self):
+        lab = rgb_to_lab([0, 0, 0])
+        assert lab[0] == pytest.approx(0.0, abs=0.01)
+
+    def test_white(self):
+        lab = rgb_to_lab([255, 255, 255])
+        assert lab[0] == pytest.approx(100.0, abs=0.5)
+
+    def test_red_positive_a(self):
+        lab = rgb_to_lab([255, 0, 0])
+        assert lab[1] > 0  # red has positive a*
+
+    def test_green_negative_a(self):
+        lab = rgb_to_lab([0, 255, 0])
+        assert lab[1] < 0  # green has negative a*
+
+    def test_blue_negative_b(self):
+        lab = rgb_to_lab([0, 0, 255])
+        assert lab[2] < 0  # blue has negative b*
+
+    def test_batch(self):
+        rgb = np.array([[255, 0, 0], [0, 255, 0], [0, 0, 255]])
+        lab = rgb_to_lab(rgb)
+        assert lab.shape == (3, 3)


### PR DESCRIPTION
Mode bounds (auto, tungsten, cloudy, etc.) are hardcoded in the template and can extend beyond the calibrated CT curve. Clamp each mode lo/hi to the actual measured range so the AWB algorithm never searches outside the CT calibrated range.